### PR TITLE
keypad-test: update cflags include path

### DIFF
--- a/src/keypad-test/Makefile.am
+++ b/src/keypad-test/Makefile.am
@@ -2,7 +2,7 @@ AUTOMAKE_OPTIONS = subdir-objects
 GITCOMMIT:= $(shell git describe --abbrev=12 --dirty --always)
 
 keypad_test_SOURCES = main.c ../spi-lcd/cairo-test/lcd-display.c
-keypad_test_CFLAGS = -O3 -Wall -I../spi-lcd/cairo-test/
+keypad_test_CFLAGS = -O3 -Wall -I$(top_srcdir)/src/spi-lcd/cairo-test/
 keypad_test_CPPFLAGS = -DGITCOMMIT="\"${GITCOMMIT}\""
 keypad_test_LDFLAGS = -lcairo
 


### PR DESCRIPTION
Add full relative path to Makefile.am with top_srcdir macro. This is because in Yocto, the build dir is separate from the source dir and the build occurs from the build dir resulting in lcd-display.h not being correctly included.