### PR TITLE
tshwctl / lcd-helper: update to libgpiod 2.x API

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,11 @@ AC_PROG_CC
 AC_SEARCH_LIBS([cairo_create], [cairo], [],
 		[AC_MSG_FAILURE([libcairo not found])])
 
+
+PKG_CHECK_MODULES([LIBGPIOD], [libgpiod >= 2.2], [], [
+  AC_MSG_ERROR([libgpiod is required but was not found])
+])
+
 # Checks for header files.
 AC_CHECK_HEADERS([fcntl.h stdint.h stdlib.h string.h sys/ioctl.h unistd.h])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,6 @@
 GITCOMMIT:= $(shell git describe --abbrev=12 --dirty --always)
 
-tshwctl_SOURCES = tshwctl.c
+tshwctl_SOURCES = tshwctl.c gpiod-helper.c
 tshwctl_CFLAGS = -Wall
 tshwctl_CPPFLAGS = -DGITCOMMIT="\"${GITCOMMIT}\""
 tshwctl_LDADD = -lgpiod

--- a/src/gpiod-helper.c
+++ b/src/gpiod-helper.c
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-FileCopyrightText: 2023 Kent Gibson <warthog618@gmail.com>
+
+#include <errno.h>
+#include <gpiod.h>
+#include <stdio.h>
+
+/* The following helper functions were pulled mostly verbatim from the libgpiod
+ * examples. More information on each function is included in its header.
+ */
+
+/* Request a single line as an input.
+ * Returns struct gpiod_line_request* on success or NULL on failure.
+ * Unfortunately most libgpiod functions don't set errno on failure.
+ *
+ * Pulled from the v2.2.x branch:
+ * https://github.com/brgl/libgpiod/blob/v2.2.x/examples/get_line_value.c
+ */
+
+struct gpiod_line_request *request_input_line(const char *chip_path,
+					      unsigned int offset,
+					      const char *consumer)
+{
+	struct gpiod_request_config *req_cfg = NULL;
+	struct gpiod_line_request *request = NULL;
+	struct gpiod_line_settings *settings;
+	struct gpiod_line_config *line_cfg;
+	struct gpiod_chip *chip;
+	int ret;
+
+	chip = gpiod_chip_open(chip_path);
+	if (!chip)
+		return NULL;
+
+	settings = gpiod_line_settings_new();
+	if (!settings)
+		goto close_chip;
+
+	gpiod_line_settings_set_direction(settings, GPIOD_LINE_DIRECTION_INPUT);
+
+	line_cfg = gpiod_line_config_new();
+	if (!line_cfg)
+		goto free_settings;
+
+	ret = gpiod_line_config_add_line_settings(line_cfg, &offset, 1,
+						  settings);
+	if (ret)
+		goto free_line_config;
+
+	if (consumer) {
+		req_cfg = gpiod_request_config_new();
+		if (!req_cfg)
+			goto free_line_config;
+
+		gpiod_request_config_set_consumer(req_cfg, consumer);
+	}
+
+	request = gpiod_chip_request_lines(chip, req_cfg, line_cfg);
+
+	gpiod_request_config_free(req_cfg);
+
+free_line_config:
+	gpiod_line_config_free(line_cfg);
+
+free_settings:
+	gpiod_line_settings_free(settings);
+
+close_chip:
+	gpiod_chip_close(chip);
+
+	return request;
+}
+
+
+/* Request a single line as an output.
+ * Returns struct gpiod_line_request* on success or NULL on failure.
+ * Unfortunately most libgpiod functions don't set errno on failure.
+ *
+ * Pulled from the v2.2.x branch:
+ * https://github.com/brgl/libgpiod/blob/v2.2.x/examples/toggle_line_value.c
+ */
+struct gpiod_line_request *
+request_output_line(const char *chip_path, unsigned int offset,
+		    enum gpiod_line_value value, const char *consumer)
+{
+	struct gpiod_request_config *req_cfg = NULL;
+	struct gpiod_line_request *request = NULL;
+	struct gpiod_line_settings *settings;
+	struct gpiod_line_config *line_cfg;
+	struct gpiod_chip *chip;
+	int ret;
+
+	chip = gpiod_chip_open(chip_path);
+	if (!chip)
+		return NULL;
+
+	settings = gpiod_line_settings_new();
+	if (!settings)
+		goto close_chip;
+
+	gpiod_line_settings_set_direction(settings,
+					  GPIOD_LINE_DIRECTION_OUTPUT);
+	gpiod_line_settings_set_output_value(settings, value);
+
+	line_cfg = gpiod_line_config_new();
+	if (!line_cfg)
+		goto free_settings;
+
+	ret = gpiod_line_config_add_line_settings(line_cfg, &offset, 1,
+						  settings);
+	if (ret)
+		goto free_line_config;
+
+	if (consumer) {
+		req_cfg = gpiod_request_config_new();
+		if (!req_cfg)
+			goto free_line_config;
+
+		gpiod_request_config_set_consumer(req_cfg, consumer);
+	}
+
+	request = gpiod_chip_request_lines(chip, req_cfg, line_cfg);
+
+	gpiod_request_config_free(req_cfg);
+
+free_line_config:
+	gpiod_line_config_free(line_cfg);
+
+free_settings:
+	gpiod_line_settings_free(settings);
+
+close_chip:
+	gpiod_chip_close(chip);
+
+	return request;
+}

--- a/src/gpiod-helper.h
+++ b/src/gpiod-helper.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-FileCopyrightText: 2023 Kent Gibson <warthog618@gmail.com>
+
+/* The following helper functions were pulled mostly verbatim from the libgpiod
+ * examples. More information on each function is included in its header.
+ */
+
+#pragma once
+
+#include <gpiod.h>
+#include <stdio.h>
+
+/* Request a single line as an input.
+ * Returns struct gpiod_line_request* on success or NULL on failure.
+ * Unfortunately most libgpiod functions don't set errno on failure.
+ *
+ * Pulled from the v2.2.x branch:
+ * https://github.com/brgl/libgpiod/blob/v2.2.x/examples/get_line_value.c
+ */
+
+struct gpiod_line_request *request_input_line(const char *chip_path,
+					      unsigned int offset,
+					      const char *consumer);
+
+/* Request a single line as an output.
+ * Returns struct gpiod_line_request* on success or NULL on failure.
+ * Unfortunately most libgpiod functions don't set errno on failure.
+ *
+ * Pulled from the v2.2.x branch:
+ * https://github.com/brgl/libgpiod/blob/v2.2.x/examples/toggle_line_value.c
+ */
+struct gpiod_line_request *
+request_output_line(const char *chip_path, unsigned int offset,
+		    enum gpiod_line_value value, const char *consumer);

--- a/src/spi-lcd/lcd-helper/Makefile.am
+++ b/src/spi-lcd/lcd-helper/Makefile.am
@@ -1,6 +1,7 @@
+AUTOMAKE_OPTIONS = subdir-objects
 GITCOMMIT:= $(shell git describe --abbrev=12 --dirty --always)
 
-lcd_helper_SOURCES = spi-lcd.c
+lcd_helper_SOURCES = spi-lcd.c ../../gpiod-helper.c
 lcd_helper_CFLAGS = -O3 -Wall
 lcd_helper_CPPFLAGS = -DGITCOMMIT="\"${GITCOMMIT}\""
 lcd_helper_LDADD = -lgpiod


### PR DESCRIPTION
Fixes #8 

Tested on TS-7553-V2:
- Rev D (straps and backlight only were tested, SPI LCD not directly tested)

This should be considered a major rev bump of `ts7553-utils`. Support for this in https://github.com/embeddedTS/buildroot-ts needs move to libgpiod2. Similar for https://github.com/embeddedTS/meta-ts/ needs to be updated and then the limit of prefer libgpiod 1.x removed.